### PR TITLE
Create one OrgMember document per org<->member pairing

### DIFF
--- a/api/src/graphql/connectors/index.js
+++ b/api/src/graphql/connectors/index.js
@@ -156,17 +156,16 @@ export async function createViewer({
   user, viewedOrg, driver, coreModels,
 }) {
   // creating user in core
-  const maybeUser = await coreModels.OrgMember.findOne({
+  const wantedUser = {
     userId: user.userId,
-  });
+    organizationId: viewedOrg.orgId,
+  };
+
+  const maybeUser = await coreModels.OrgMember.findOne(wantedUser);
 
   if (maybeUser === null) {
     // user doesn't exist in db
-    const newUser = new coreModels.OrgMember({
-      userId: user.userId,
-      organizationId: viewedOrg.orgId,
-    });
-
+    const newUser = new coreModels.OrgMember(wantedUser);
     await newUser.save();
   }
 

--- a/api/src/graphql/connectors/index.js
+++ b/api/src/graphql/connectors/index.js
@@ -155,7 +155,7 @@ export function createInfo(driver, { title }, infoUrl) {
 export async function createViewer({
   user, viewedOrg, driver, coreModels,
 }) {
-  // creating user in core
+  // creating user org membership in core
   const wantedUser = {
     userId: user.userId,
     organizationId: viewedOrg.orgId,
@@ -164,7 +164,9 @@ export async function createViewer({
   const maybeUser = await coreModels.OrgMember.findOne(wantedUser);
 
   if (maybeUser === null) {
-    // user doesn't exist in db
+    // user<->org pairing doesn't exist in db
+    // NOTE: there should be 1 OrgMember doc per user<->org pair.
+    // i.e. numUsers*numOrgs number of docs
     const newUser = new coreModels.OrgMember(wantedUser);
     await newUser.save();
   }


### PR DESCRIPTION
Right now if there's a single orgmember object for a user then more aren't created

Fixes https://github.com/Edgeryders-Participio/realities/issues/152 again